### PR TITLE
moved plist spritesheet decoding to a new 'PlistSpriteParser' class

### DIFF
--- a/src/PlistSpriteParser.cpp
+++ b/src/PlistSpriteParser.cpp
@@ -1,0 +1,87 @@
+#include "PlistSpriteParser.hpp"
+#include "utils.hpp"
+
+#include <utility>
+
+PlistSpriteParser::PlistSpriteParser() {}
+
+bool PlistSpriteParser::parse(std::string path, std::shared_ptr<Texture> texture, SpriteFrameCache* cache) {
+    m_texture = texture;
+
+    std::map<std::string, boost::any> dict;
+    Plist::readPlist(path.c_str(), dict);
+
+    if (dict.find("frames") == dict.end()) {
+        std::cout << "PlistSpriteParser::parse: Invalid spriteframe plist" << std::endl;
+        return false;
+    }
+
+    std::map<std::string, boost::any> frames = boost::any_cast<std::map<std::string, boost::any>>(dict["frames"]);
+
+    for (const auto& frame : frames) {
+        std::string frameName = frame.first;
+        if (frame.second.type() != typeid(std::map<std::string, boost::any>))
+            continue;
+        
+        std::map<std::string, boost::any> frameDict = boost::any_cast<std::map<std::string, boost::any>>(frame.second);
+        cache->addSpriteFrame(frameName, parseSpriteFrame(frameDict));
+    }
+
+    std::cout << "Added " + std::to_string(frames.size()) + " sprites from " + path << std::endl;
+    return true;
+}
+
+std::string removeCharacters(std::string string, char character) {
+    string.erase(std::remove(string.begin(), string.end(), character), string.end());
+    return string;
+}
+
+std::vector<int> PlistSpriteParser::bracketStringToIntArray(boost::any bstring) {
+    std::string string = boost::any_cast<std::string>(bstring);
+
+    string = removeCharacters(string, '{');
+    string = removeCharacters(string, '}');
+
+    std::vector<std::string> splitStr = split(string, ",");
+    std::vector<int> res;
+
+    for (const auto& str : splitStr) {
+        res.push_back(std::stoi(str));
+    }
+
+    return res;
+}
+    
+Point PlistSpriteParser::bracketStringToPoint(boost::any string) {
+    auto array = bracketStringToIntArray(string);
+
+    return Point(array[0], array[1]);
+}
+
+Rect PlistSpriteParser::bracketStringToRect(boost::any string) {
+    auto array = bracketStringToIntArray(string);
+
+    return Rect(array[0], array[1], array[2], array[3]);
+}
+
+std::shared_ptr<SpriteFrame> PlistSpriteParser::parseSpriteFrame(std::map<std::string, boost::any> frame) {
+    std::shared_ptr<SpriteFrame> spriteFrame = std::make_shared<SpriteFrame>();
+
+    spriteFrame->m_texCoords = bracketStringToRect(frame["textureRect"]);
+    spriteFrame->m_offset    = bracketStringToPoint(frame["spriteOffset"]);
+    spriteFrame->m_rotated   = boost::any_cast<bool>(frame["textureRotated"]);
+
+    spriteFrame->m_size = spriteFrame->m_texCoords.size;
+    spriteFrame->m_texCoords = spriteFrame->m_texCoords / m_texture->m_size;
+    
+    if (spriteFrame->m_rotated) {
+        std::swap(spriteFrame->m_texCoords.size.width, spriteFrame->m_texCoords.size.height);
+    }
+
+    spriteFrame->m_texture = m_texture;
+
+    spriteFrame->m_size /= 4.f;
+    spriteFrame->m_offset /= 4.f;
+
+    return spriteFrame;
+}

--- a/src/PlistSpriteParser.hpp
+++ b/src/PlistSpriteParser.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "SpriteFrameCache.hpp"
+#include "Texture.hpp"
+
+#include <Plist.hpp>
+
+#include <string>
+
+class PlistSpriteParser {
+public:
+    PlistSpriteParser();
+
+    bool parse(std::string path, std::shared_ptr<Texture> texture, SpriteFrameCache* cache);
+
+private:
+    std::vector<int> bracketStringToIntArray(boost::any string);
+
+    Point bracketStringToPoint(boost::any string);
+
+    Rect bracketStringToRect(boost::any string);
+
+    std::shared_ptr<SpriteFrame> parseSpriteFrame(std::map<std::string, boost::any> frame);
+
+private:
+    std::shared_ptr<Texture> m_texture;
+
+};

--- a/src/SpriteFrameCache.cpp
+++ b/src/SpriteFrameCache.cpp
@@ -4,6 +4,8 @@
 #include "Plist.hpp"
 #include "utils.hpp"
 
+#include "PlistSpriteParser.hpp"
+
 #include <thread>
 
 void SpriteFrameCache::loadSprite(std::string path, LoadingLayer* loadingLayer) {
@@ -35,6 +37,7 @@ void SpriteFrameCache::loadSprite(std::string path, LoadingLayer* loadingLayer) 
 }
 
 void SpriteFrameCache::loadSpriteFramesFromPlist(std::string path, LoadingLayer* loadingLayer) {
+    // TODO: Abstract the following chunk of code into a function. Duplicate code with the code in SpriteFrameCache::loadSprite
     std::shared_ptr<Texture> texture;
     if (loadingLayer) {
         Texture::getImageData((path + "-uhd.png").c_str(), loadingLayer);
@@ -50,68 +53,18 @@ void SpriteFrameCache::loadSpriteFramesFromPlist(std::string path, LoadingLayer*
 
     std::cout << texture->m_id << std::endl;
     std::cout << texture->m_slot << " SUPPOSED TO BE " << m_spriteSlot << std::endl;
+    // TODO: End
 
-    std::map<std::string, boost::any> dict;
-    Plist::readPlist((path + "-uhd.plist").c_str(), dict);
+    PlistSpriteParser parser;
 
-    if (dict.find("frames") == dict.end()) {
-        std::cout << "SpriteFrameCache::loadSpriteFramesFromPlist: Invalid spriteframe plist" << std::endl;
+    if (!parser.parse(path + "-uhd.plist", texture, this))
         return;
-    }
-
-    std::map<std::string, boost::any> frames = boost::any_cast<std::map<std::string, boost::any>>(dict["frames"]);
     
-    for (const auto& frame : frames) {
-        std::string frameName = frame.first;
-        
-        if (frame.second.type() != typeid(std::map<std::string, boost::any>))
-            continue;
-        
-        std::map<std::string, boost::any> frameDict = boost::any_cast<std::map<std::string, boost::any>>(frame.second);
-        std::shared_ptr<SpriteFrame> spriteFrame = std::make_shared<SpriteFrame>();
-
-        std::string textureRect = boost::any_cast<std::string>(frameDict["textureRect"]);
-        
-        textureRect.erase(std::remove(textureRect.begin(), textureRect.end(), '{'), textureRect.end());
-        textureRect.erase(std::remove(textureRect.begin(), textureRect.end(), '}'), textureRect.end());
-
-        std::vector<std::string> splitRect = split(textureRect, ",");
-        
-        spriteFrame->m_texCoords.position.x = std::stoi(splitRect[0]);
-        spriteFrame->m_texCoords.position.y = std::stoi(splitRect[1]);
-        spriteFrame->m_texCoords.size.width = std::stoi(splitRect[2]);
-        spriteFrame->m_texCoords.size.height = std::stoi(splitRect[3]);
-
-        spriteFrame->m_texCoords = spriteFrame->m_texCoords / texture->m_size;
-
-        spriteFrame->m_size.width = std::stoi(splitRect[2]);
-        spriteFrame->m_size.height = std::stoi(splitRect[3]);
-
-        std::string spriteOffset = boost::any_cast<std::string>(frameDict["spriteOffset"]);
-
-        spriteOffset.erase(std::remove(spriteOffset.begin(), spriteOffset.end(), '{'), spriteOffset.end());
-        spriteOffset.erase(std::remove(spriteOffset.begin(), spriteOffset.end(), '}'), spriteOffset.end());
-
-        std::vector<std::string> splitOffset = split(spriteOffset, ",");
-
-        spriteFrame->m_offset.x = std::stoi(splitOffset[0]);
-        spriteFrame->m_offset.y = std::stoi(splitOffset[1]);
-        
-        spriteFrame->m_rotated = boost::any_cast<bool>(frameDict["textureRotated"]);
-
-        if (spriteFrame->m_rotated) {
-            std::swap(spriteFrame->m_texCoords.size.width, spriteFrame->m_texCoords.size.height);
-        }
-
-        spriteFrame->m_texture = texture;
-
-        spriteFrame->m_size /= 4.f;
-        spriteFrame->m_offset /= 4.f;
-
-        m_spriteFrames[frameName] = spriteFrame;
-    }
-    std::cout << "Added " + std::to_string(frames.size()) + " sprites from " + path << std::endl;
     m_spriteSlot++;
+}
+
+void SpriteFrameCache::addSpriteFrame(std::string name, std::shared_ptr<SpriteFrame> spriteFrame) {
+    m_spriteFrames[name] = spriteFrame;
 }
 
 std::shared_ptr<SpriteFrame> SpriteFrameCache::getSpriteFrameByName(std::string name) {

--- a/src/SpriteFrameCache.hpp
+++ b/src/SpriteFrameCache.hpp
@@ -19,6 +19,8 @@ public:
 
     void loadSprite(std::string path, LoadingLayer* loadingLayer=nullptr);
     void loadSpriteFramesFromPlist(std::string plistPath, LoadingLayer* loadingLayer=nullptr);
+
+    void addSpriteFrame(std::string name, std::shared_ptr<SpriteFrame> spriteFrame);
     
     std::shared_ptr<SpriteFrame> getSpriteFrameByName(std::string name);
 


### PR DESCRIPTION
I found the function `SpriteFrameCache::loadSpriteFramesFromPlist` to be pretty long. So I created a new class `PlistSpriteParser` to put the code into and added some functions to parse the bracket strings since there was duplicate code. This change works and I've tested it.

I would have liked to put these files into folders so that it's a bit more organised but there might be reasons not to.